### PR TITLE
Fix CI pipeline fails

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
 	"compilerOptions": {
 		"target": "es2023",
 		"module": "es2022",
-		"moduleResolution": "node",
-		"ignoreDeprecations": "5.0",
+		"moduleResolution": "bundler",
 		"skipLibCheck": true,
 		"allowJs": true,
 		"strict": true,


### PR DESCRIPTION
closes:#103

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   Migrate tsconfig moduleResolution from deprecated "node" to "bundler"


Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
The CI pipeline (`check-types` step) fails with the following error when running `npx tsc --noemit`:
tsconfig.json(5,23): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.
This occurs because the project was upgraded to _TypeScript 6.x_ (`^6.0.2`), which deprecates the `"moduleResolution": "node"` (alias for `node10`) option. The previous workaround `"ignoreDeprecations": "5.0"` is no longer valid for TS 6.x deprecations. Setting `"ignoreDeprecations": "6.0"` suppresses the error but causes ESLint strict type-checked rules to flag it as a code smell.


